### PR TITLE
Inspection Module crashes when Tx has errors

### DIFF
--- a/app/client/src/stories/transactions/inspection/InspectionModule.jsx
+++ b/app/client/src/stories/transactions/inspection/InspectionModule.jsx
@@ -231,7 +231,7 @@ function InspectionModule() {
                             :
                             <>
                                 <Header textAlign="left" sub className="mb-2 text-lg">
-                                    <span className="text-gray-700"> TxHash: </span>
+                                    <span className="text-gray-700">TxHash:&nbsp;</span>
                                     <span className="text-gray-500">{txObj["txHash"]}</span>
                                 </Header>
                                 <div

--- a/app/client/src/util/transaction.js
+++ b/app/client/src/util/transaction.js
@@ -109,7 +109,7 @@ export const parseRpcTxObject = (rpcTxObject) => {
     // We will show count of VIN/VOUT in table and allow dropdown rows for any individual VIN/VOUT
     const builtTxObj = {
         "wholeTx": rpcTxObject,
-        "txHash": get(rpcTxObject,["Vout", "0", "ValueStore"]) ? get(rpcTxObject, ["Vout", "0", "ValueStore", "TxHash"]) : get(rpcTxObject["Vout", "0", "DataStore", "DSLinker", "TxHash"]),
+        "txHash": get(rpcTxObject, ["Vout", 0, "ValueStore"]) ? get(rpcTxObject, ["Vout", 0, "ValueStore", "TxHash"]) : get(rpcTxObject, ["Vout", 0, "DataStore", "DSLinker", "TxHash"]),
         "valueStoreCount": valueStoreCount,
         "dataStoreCount": dataStoreCount,
         "vinCount": vins.length,


### PR DESCRIPTION
The module does not crash anymore when errors are present in the transaction object. Some of the component's parts were also updated to avoid any conflicts when dealing with an empty object as a possible response coming from the RPC when expecting a transaction.